### PR TITLE
I added a new option to allow modelers to set the loader color.

### DIFF
--- a/webcomponents/web-components/Tile/readme.md
+++ b/webcomponents/web-components/Tile/readme.md
@@ -12,3 +12,4 @@ Description
 | iconColor | The icon's color |     black    |
 | backgroundColor | The element's background color |    white     |
 | isLoading | Sets the element in a loading state  |    false    |
+| spinnerColor | The spinner color |    black     |

--- a/webcomponents/web-components/Tile/readme.md
+++ b/webcomponents/web-components/Tile/readme.md
@@ -12,4 +12,4 @@ Description
 | iconColor | The icon's color |     black    |
 | backgroundColor | The element's background color |    white     |
 | isLoading | Sets the element in a loading state  |    false    |
-| spinnerColor | The spinner color |    black     |
+| loaderColor | The loader color |    black     |

--- a/webcomponents/web-components/Tile/tile.js
+++ b/webcomponents/web-components/Tile/tile.js
@@ -13,7 +13,7 @@ class TileElement extends HTMLElement {
             backgroundColor: null,
             onClick: null,
             isLoading: false,
-            spinnerColor: null
+            loaderColor: null
         };
 
         this._tile = getTile();
@@ -70,8 +70,8 @@ class TileElement extends HTMLElement {
         this.render();
     }
 
-    set spinnerColor(value) {
-        this._configuration.spinnerColor = value;
+    set loaderColor(value) {
+        this._configuration.loaderColor = value;
         this.render();
     }
 }
@@ -92,7 +92,7 @@ function getTileContent(configuration) {
 
     if (configuration.isLoading === true) {
         const container = document.createElement('div');
-        container.appendChild(getLoader(configuration.spinnerColor));
+        container.appendChild(getLoader(configuration.loaderColor === null ? configuration.iconColor : configuration.loaderColor));
         container.className = 'col-12 text-center';
 
         row.appendChild(container);

--- a/webcomponents/web-components/Tile/tile.js
+++ b/webcomponents/web-components/Tile/tile.js
@@ -12,7 +12,8 @@ class TileElement extends HTMLElement {
             textColor: null,
             backgroundColor: null,
             onClick: null,
-            isLoading: false
+            isLoading: false,
+            spinnerColor: null
         };
 
         this._tile = getTile();
@@ -68,6 +69,11 @@ class TileElement extends HTMLElement {
         this._configuration.isLoading = value === true;
         this.render();
     }
+
+    set spinnerColor(value) {
+        this._configuration.spinnerColor = value;
+        this.render();
+    }
 }
 
 function getTile() {
@@ -86,7 +92,7 @@ function getTileContent(configuration) {
 
     if (configuration.isLoading === true) {
         const container = document.createElement('div');
-        container.appendChild(getLoader(configuration.iconColor));
+        container.appendChild(getLoader(configuration.spinnerColor));
         container.className = 'col-12 text-center';
 
         row.appendChild(container);

--- a/webcomponents/web-components/Tile/tile.stories.js
+++ b/webcomponents/web-components/Tile/tile.stories.js
@@ -10,13 +10,14 @@ storiesOf('Tile', module)
     .add('default', () => {
         const component = createElement();
 
-        component.title = text('Title', 'Sales balance');
+        component.title = text('Title', 'Teste Tile');
         component.value = text('Value', '+2%');
         component.icon = select('Icon', faIcons, 'arrow-up');
         component.textColor = color('Text Color', '#000000');
         component.iconColor = color('Icon Color', '#1F8E22');
         component.backgroundColor = color('Background Color', '#FFEFC6');
-        component.isLoading = boolean('Is Loading?', false);
+        component.isLoading = boolean('Is Loading?', false);        
+        component.spinnerColor = color('Spinner Color', '#1F8E22');
 
         return component;
 

--- a/webcomponents/web-components/Tile/tile.stories.js
+++ b/webcomponents/web-components/Tile/tile.stories.js
@@ -10,14 +10,14 @@ storiesOf('Tile', module)
     .add('default', () => {
         const component = createElement();
 
-        component.title = text('Title', 'Teste Tile');
+        component.title = text('Title', 'Sales balance');
         component.value = text('Value', '+2%');
         component.icon = select('Icon', faIcons, 'arrow-up');
         component.textColor = color('Text Color', '#000000');
         component.iconColor = color('Icon Color', '#1F8E22');
         component.backgroundColor = color('Background Color', '#FFEFC6');
         component.isLoading = boolean('Is Loading?', false);        
-        component.spinnerColor = color('Spinner Color', '#1F8E22');
+        component.loaderColor = color('Loader Color', '#1F8E22');
 
         return component;
 


### PR DESCRIPTION
In the previous version the component was using the color of the icon on the tiles. When the icon was white, upon activating the loader it was invisible to the user. 