### PR TITLE
Reviewed uploader availability when code is not filled

### DIFF
--- a/webcomponents/web-components/FileUploader/file-uploader.js
+++ b/webcomponents/web-components/FileUploader/file-uploader.js
@@ -452,7 +452,7 @@ class OmniaFileUpload extends HTMLElement {
     set state(newValue) {
         this._settings.state = newValue;
 		
-		if(!this._settings.state._code)
+		if(this._settings.state._code == null)
 			this._button.disabled = true;
 		else
 			this._button.disabled = false;

--- a/webcomponents/web-components/FileUploader/file-uploader.js
+++ b/webcomponents/web-components/FileUploader/file-uploader.js
@@ -451,7 +451,12 @@ class OmniaFileUpload extends HTMLElement {
 
     set state(newValue) {
         this._settings.state = newValue;
-
+		
+		if(!this._settings.state._code)
+			this._button.disabled = true;
+		else
+			this._button.disabled = false;
+			
         if (this._settings.state != null && this._settings.lastCodeValue !== this._settings.state._code) {
             this._settings.lastCodeValue = this._settings.state._code;
             this.save();


### PR DESCRIPTION
Disable uploader button if entity code is not filled (file uploads can only be made when entity _code is filled)